### PR TITLE
Fixed dead object

### DIFF
--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -11,7 +11,8 @@ using namespace std::chrono;
 RankStatusMap::RankStatusMap( int _myrank, int _size )
   : ranks_active( _myrank, _size, TRUE ),
     ranks_duration( _myrank, _size, 0 ),
-    size(_size)
+    size(_size),
+    o(string(LOG_DIR)+string("/mpi.rank_map.log"))
 {  
   for (int i = 0; i < size; i++){
       auto now = static_cast<TIME_T>(duration_cast<seconds>(chrono::system_clock::now().time_since_epoch()).count());
@@ -31,7 +32,6 @@ RankStatusMap::setRankExit(int i)
 
 void RankStatusMap::output_map()
 {
-  ofstream o(string(LOG_DIR)+string("/mpi.rank_map.log"));
   TIME_T duration;
   
   o << "active rank | " << localtimestamp() << endl;
@@ -46,5 +46,5 @@ void RankStatusMap::output_map()
       << setw(5) << i
       << setw(20) << right << duration << " sec." << endl;
   }
-  o.close();
+  o.flush();
 }

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -11,9 +11,14 @@ class RankStatusMap
   MPISharedMap<TIME_T> ranks_duration;
 
   int size;
+  std::ofstream o;
   
 public:
   RankStatusMap( int _myrank, int _size );
+  virtual ~RankStatusMap()
+  {
+    o.close();
+  }
 
   void mpi_bcast_from( int root_rank ) {
     ranks_active.mpi_bcast_from( root_rank );

--- a/worker_thread.hpp
+++ b/worker_thread.hpp
@@ -4,7 +4,6 @@
 #include <thread>
 #include <string>
 #include <sstream>
-#include <mutex>
 #include <cstdlib>
 #include <cassert>
 
@@ -14,7 +13,6 @@ class WorkerThread
 {
   bool completed;
   std::thread* th;
-  std::mutex mtx;
 public:
   WorkerThread() 
   :completed(false),th(nullptr) 
@@ -45,12 +43,10 @@ public:
   }
 
   void set_completed() {
-      std::lock_guard<std::mutex> lock(mtx);
       completed=true;
   }
 
   bool is_completed() { 
-      std::lock_guard<std::mutex> lock(mtx);
       return completed; 
   }
 };

--- a/worker_thread.hpp
+++ b/worker_thread.hpp
@@ -28,7 +28,8 @@ public:
         command << cmd << " " << args;
         //logger << stamp << "executing -> " << command.str() << endl;
         balancer_cmd << "export BALANCER=1; " << command.str() << std::endl;
-        std::system(balancer_cmd.str().c_str());
+        const auto str = balancer_cmd.str(); // temporary object must be stored once
+        std::system(str.c_str());
         set_completed();
     };
     th = new std::thread(worker_func, cmd, args);


### PR DESCRIPTION
stringstream.str().c_str()に気を付けよう

str()はstringの一時オブジェクトをよこすので，str()の終了時にどこかへコピーしておかないと破棄されてしまう．c_str()は破棄されたポインタへアクセスするので未定義動作となってしまう．