### PR TITLE
Mpi shared memory

### DIFF
--- a/argument_list.hpp
+++ b/argument_list.hpp
@@ -1,19 +1,33 @@
 #ifndef __BALANCER_ARGUMENT_LIST_HPP__
 #define __BALANCER_ARGUMENT_LIST_HPP__
 
+#include <mpi.h>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <fstream>
+#include <memory>
+
+#include "mpi_shared_array.hpp"
 
 class ArgumentsList
 {
-  std::vector<std::string> arguments;
+  template<typename T>
+  using sharedArrayPtr = std::shared_ptr<MPISharedArray<T>>;
+
+  const int myrank;
+  const int noderank;
+  const int nodesize;
+  const MPI_Comm nodecomm;
+  std::vector<sharedArrayPtr<char>> arguments;
 public:
-  ArgumentsList(std::string filename) {
+  ArgumentsList(std::string filename, int _myrank, int _noderank, int _nodesize, MPI_Comm _nodecomm)
+  : myrank(_myrank), noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
+  {
     readfile(filename);
   }
-  ArgumentsList(char* filename[], int nfile){
+  ArgumentsList(char* filename[], int nfile, int _myrank, int _noderank, int _nodesize, MPI_Comm _nodecomm)
+  : myrank(_myrank), noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
+  {
     for( int i = 0; i < nfile ; i++ )
       readfile(filename[i]);
   }
@@ -23,12 +37,19 @@ public:
     if( ifs.fail() )
       std::cerr << "File " << filename << " does not exist. Please check!" << std::endl;
     while( getline(ifs, args) ) {
-      if( args[0] != '#' )
-      arguments.push_back(args);
+      if( args[0] != '#' ){
+          auto c_str = const_cast<char*>(args.c_str());
+          auto ptr = std::make_shared<MPISharedArray<char>>
+            (myrank, args.size(), noderank, nodesize, nodecomm, c_str);
+          arguments.push_back(ptr);
+      }
     }
   }
   std::size_t size() { return arguments.size(); }
-  std::string& operator[](int i) { return arguments[i]; }
+  const std::string operator[](int i) const{
+      auto str = std::string{arguments[i]->data()};
+      return str; 
+  }
 };
 
 #endif

--- a/balancer.cpp
+++ b/balancer.cpp
@@ -35,107 +35,108 @@ int main(int argc, char* argv[])
   int myrank;
 
   MPI_Init(&argc,&argv);
-  MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+  {
+      MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
+      MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
 
-  int nodesize;
-  int noderank;
-  MPI_Comm nodecomm;
+      int nodesize;
+      int noderank;
+      MPI_Comm nodecomm;
 
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, myrank,
-          MPI_INFO_NULL, &nodecomm);
+      MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, myrank,
+              MPI_INFO_NULL, &nodecomm);
 
-  MPI_Comm_size(nodecomm, &nodesize);
-  MPI_Comm_rank(nodecomm, &noderank);
+      MPI_Comm_size(nodecomm, &nodesize);
+      MPI_Comm_rank(nodecomm, &noderank);
 
 
-  string logfile
-    = string(LOG_DIR)+string("/mpi.proc.")
-    + to_string((long long)myrank)
-    + string(".log");
-  
-  logger.open(logfile);
+      string logfile
+          = string(LOG_DIR)+string("/mpi.proc.")
+          + to_string((long long)myrank)
+          + string(".log");
 
-  if( argc < 3 ) {
-    if(myrank == 0) usage(argc, argv);
-    logger << stamp << "error: please check command line arguments" << endl; 
-    return 1;
-  }
+      logger.open(logfile);
 
-  Command              cmd( argv[1] );
-  ArgumentsList        argslist( &argv[2], argc-2 );
-  JobStatusMap         job_status_map( myrank, argslist.size(), noderank, nodesize, nodecomm);
-  RankStatusMap        rank_status_map( myrank, numprocs, noderank, nodesize, nodecomm);
-  WorkerThreadManager  workman(&cmd, &argslist);
-
-  if(myrank == 0) {
-    cout << "*** balancer: command-level MPI parallelization ***" << endl;
-    cout << "front-end: [ " << string(cmd) << " ]" << endl;
-    for( int i = 2; i < argc ; i++ )
-      cout << "list of back-ends: " << argv[i] << endl;
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-  assert(sizeof(long long int) == sizeof(time_t));
-
-  while(true) {
-    // schedule jobs to processes by ascending order of rank
-    for( int i = 0; i < numprocs; i++ ) {
-      if ( i == myrank ) { // if rank id indicates this process
-
-        if ( workman.isDeallocatable() ){ // if the thread completes the task
-          auto job_id = workman.getCurrentJobId();
-          job_status_map.setExit(job_id);
-          workman.deallocate();
-        }
-        
-        if ( job_status_map.existWaitJobs() )
-        {
-          if ( !workman.isAllocated() ) {
-            auto job_id = job_status_map.getNextWaitJob();
-            job_status_map.setExecuted(job_id);
-            workman.allocate(job_id); 
-          }
-        }
-        else// no job and not allocation will cause termination
-        {
-          if ( !workman.isAllocated() ) {
-            rank_status_map.setRankExit( myrank );
-          }
-        }
+      if( argc < 3 ) {
+          if(myrank == 0) usage(argc, argv);
+          logger << stamp << "error: please check command line arguments" << endl; 
+          return 1;
       }
+
+      Command              cmd( argv[1] );
+      ArgumentsList        argslist( &argv[2], argc-2 );
+      JobStatusMap         job_status_map( myrank, argslist.size(), noderank, nodesize, nodecomm);
+      RankStatusMap        rank_status_map( myrank, numprocs, noderank, nodesize, nodecomm);
+      WorkerThreadManager  workman(&cmd, &argslist);
 
       if(myrank == 0) {
-          logger << "begin bcast:" << i << endl;
+          cout << "*** balancer: command-level MPI parallelization ***" << endl;
+          cout << "front-end: [ " << string(cmd) << " ]" << endl;
+          for( int i = 2; i < argc ; i++ )
+              cout << "list of back-ends: " << argv[i] << endl;
       }
 
-      // share the status of jobs with the next process,
-      // the last process broadcast the status to the all processes
-      job_status_map.mpi_bcast_from( i );
-      rank_status_map.mpi_bcast_from( i );
+      MPI_Barrier(MPI_COMM_WORLD);
+      assert(sizeof(long long int) == sizeof(time_t));
 
-      if(myrank == 0) {
-          logger << "done bcast:" << i << endl;
+      while(true) {
+          // schedule jobs to processes by ascending order of rank
+          for( int i = 0; i < numprocs; i++ ) {
+              if ( i == myrank ) { // if rank id indicates this process
+
+                  if ( workman.isDeallocatable() ){ // if the thread completes the task
+                      auto job_id = workman.getCurrentJobId();
+                      job_status_map.setExit(job_id);
+                      workman.deallocate();
+                  }
+
+                  if ( job_status_map.existWaitJobs() )
+                  {
+                      if ( !workman.isAllocated() ) {
+                          auto job_id = job_status_map.getNextWaitJob();
+                          job_status_map.setExecuted(job_id);
+                          workman.allocate(job_id); 
+                      }
+                  }
+                  else// no job and not allocation will cause termination
+                  {
+                      if ( !workman.isAllocated() ) {
+                          rank_status_map.setRankExit( myrank );
+                      }
+                  }
+              }
+
+              if(myrank == 0) {
+                  logger << "begin bcast:" << i << endl;
+              }
+
+              // share the status of jobs with the next process,
+              // the last process broadcast the status to the all processes
+              job_status_map.mpi_bcast_from( i );
+              rank_status_map.mpi_bcast_from( i );
+
+              if(myrank == 0) {
+                  logger << "done bcast:" << i << endl;
+              }
+          }
+
+          if (myrank == 0) {
+              job_status_map.output_map(&cmd, &argslist);
+              rank_status_map.output_map();
+          }
+
+          // if no more job, breaking loop
+          if ( !job_status_map.existWaitJobs() ) {
+              logger << stamp << "the worker thread waits for exit" << endl;
+              if ( rank_status_map.isAllExit() )
+                  break;
+          }
+
+          // wait until the next scheduling interval
+          std::this_thread::sleep_for(std::chrono::seconds(SCHEDULE_INTERVAL));
       }
-    }
 
-    if (myrank == 0) {
-      job_status_map.output_map(&cmd, &argslist);
-      rank_status_map.output_map();
-    }
-
-    // if no more job, breaking loop
-    if ( !job_status_map.existWaitJobs() ) {
-      logger << stamp << "the worker thread waits for exit" << endl;
-      if ( rank_status_map.isAllExit() )
-        break;
-    }
-
-    // wait until the next scheduling interval
-    std::this_thread::sleep_for(std::chrono::seconds(SCHEDULE_INTERVAL));
-    MPI_Barrier(MPI_COMM_WORLD);
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(MPI_COMM_WORLD);
+  } // mpi init scope
   MPI_Finalize();  
 }

--- a/balancer.cpp
+++ b/balancer.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
       }
 
       Command              cmd( argv[1] );
-      ArgumentsList        argslist( &argv[2], argc-2 );
+      ArgumentsList        argslist( &argv[2], argc-2, myrank, noderank, nodesize, nodecomm );
       JobStatusMap         job_status_map( myrank, argslist.size(), noderank, nodesize, nodecomm);
       RankStatusMap        rank_status_map( myrank, numprocs, noderank, nodesize, nodecomm);
       WorkerThreadManager  workman(&cmd, &argslist);

--- a/balancer.cpp
+++ b/balancer.cpp
@@ -38,12 +38,23 @@ int main(int argc, char* argv[])
   MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
   MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
 
+  int nodesize;
+  int noderank;
+  MPI_Comm nodecomm;
+
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, myrank,
+          MPI_INFO_NULL, &nodecomm);
+
+  MPI_Comm_size(nodecomm, &nodesize);
+  MPI_Comm_rank(nodecomm, &noderank);
+
+
   string logfile
     = string(LOG_DIR)+string("/mpi.proc.")
     + to_string((long long)myrank)
     + string(".log");
   
-  //logger.open(logfile);
+  logger.open(logfile);
 
   if( argc < 3 ) {
     if(myrank == 0) usage(argc, argv);
@@ -53,8 +64,8 @@ int main(int argc, char* argv[])
 
   Command              cmd( argv[1] );
   ArgumentsList        argslist( &argv[2], argc-2 );
-  JobStatusMap         job_status_map( myrank, argslist.size() );
-  RankStatusMap        rank_status_map( myrank, numprocs );
+  JobStatusMap         job_status_map( myrank, argslist.size(), noderank, nodesize, nodecomm);
+  RankStatusMap        rank_status_map( myrank, numprocs, noderank, nodesize, nodecomm);
   WorkerThreadManager  workman(&cmd, &argslist);
 
   if(myrank == 0) {
@@ -70,7 +81,6 @@ int main(int argc, char* argv[])
   while(true) {
     // schedule jobs to processes by ascending order of rank
     for( int i = 0; i < numprocs; i++ ) {
-
       if ( i == myrank ) { // if rank id indicates this process
 
         if ( workman.isDeallocatable() ){ // if the thread completes the task
@@ -95,10 +105,18 @@ int main(int argc, char* argv[])
         }
       }
 
+      if(myrank == 0) {
+          logger << "begin bcast:" << i << endl;
+      }
+
       // share the status of jobs with the next process,
       // the last process broadcast the status to the all processes
       job_status_map.mpi_bcast_from( i );
       rank_status_map.mpi_bcast_from( i );
+
+      if(myrank == 0) {
+          logger << "done bcast:" << i << endl;
+      }
     }
 
     if (myrank == 0) {
@@ -108,7 +126,7 @@ int main(int argc, char* argv[])
 
     // if no more job, breaking loop
     if ( !job_status_map.existWaitJobs() ) {
-      //logger << stamp << "the worker thread waits for exit" << endl;
+      logger << stamp << "the worker thread waits for exit" << endl;
       if ( rank_status_map.isAllExit() )
         break;
     }

--- a/balancer.cpp
+++ b/balancer.cpp
@@ -70,8 +70,6 @@ int main(int argc, char* argv[])
   while(true) {
     // schedule jobs to processes by ascending order of rank
     for( int i = 0; i < numprocs; i++ ) {
-      job_status_map.mpi_bcast_from( i );
-      rank_status_map.mpi_bcast_from( i );
 
       if ( i == myrank ) { // if rank id indicates this process
 

--- a/define.hpp
+++ b/define.hpp
@@ -1,5 +1,5 @@
-#define TRUE  1
-#define FALSE 0
+#define TRUE  int{1}
+#define FALSE int{0}
 
 #define LOG_DIR "./results"
 

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -19,8 +19,7 @@ JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize
     exec_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
     exit_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
     start_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
-    end_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
-    o(string(LOG_DIR)+string("/mpi.job_map.log"))
+    end_time( myrank, size, noderank, nodesize, nodecomm, 0 )
 {}
 
 

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -9,14 +9,17 @@
 using namespace std;
 using namespace std::chrono;
 
-JobStatusMap::JobStatusMap( int _myrank, int _size )
-  : size(_size),
-    myrank(_myrank),
-    wait_jobs( myrank, size, TRUE ),
-    exec_jobs( myrank, size, FALSE ),
-    exit_jobs( myrank, size, FALSE ),
-    start_time( myrank, size, 0 ),
-    end_time( myrank, size, 0 ),
+JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm )
+  : myrank(_myrank),
+    size(_size),
+    noderank(_noderank),
+    nodesize(_nodesize),
+    nodecomm(_nodecomm),
+    wait_jobs( myrank, size, noderank, nodesize, nodecomm, TRUE ),
+    exec_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
+    exit_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
+    start_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
+    end_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
     o(string(LOG_DIR)+string("/mpi.job_map.log"))
 {}
 

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -19,13 +19,13 @@ JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize
     exec_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
     exit_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
     start_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
-    end_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
-    o(string(LOG_DIR)+string("/mpi.job_map.log"))
+    end_time( myrank, size, noderank, nodesize, nodecomm, 0 )
 {}
 
 
 void JobStatusMap::output_map(Command* cmd, ArgumentsList* arglist)
 {
+  std::ofstream o(string(LOG_DIR)+string("/mpi.job_map.log"));
   o << "wait exec exit job | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {
     auto now = static_cast<TIME_T>(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
@@ -42,7 +42,7 @@ void JobStatusMap::output_map(Command* cmd, ArgumentsList* arglist)
       << setw(40) << left << cmd->get_str() + " " + (*arglist)[i] << " "
       << setw(20) << right << t << " sec." << endl;
   }
-  o.flush();
+  o.close();
 }
 
 void

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -18,8 +18,8 @@ JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize
     wait_jobs( myrank, size, noderank, nodesize, nodecomm, TRUE ),
     exec_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
     exit_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
-    start_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
-    end_time( myrank, size, noderank, nodesize, nodecomm, 0 )
+    start_time( myrank, size, noderank, nodesize, nodecomm, TIME_T{0} ),
+    end_time( myrank, size, noderank, nodesize, nodecomm, TIME_T{0} )
 {}
 
 

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -25,7 +25,7 @@ JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize
 
 void JobStatusMap::output_map(Command* cmd, ArgumentsList* arglist)
 {
-  std::ofstream o(string(LOG_DIR)+string("/mpi.job_map.log"));
+  auto o = ofstream{ string(LOG_DIR)+string("/mpi.job_map.log")};
   o << "wait exec exit job | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {
     auto now = static_cast<TIME_T>(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -9,14 +9,18 @@
 using namespace std;
 using namespace std::chrono;
 
-JobStatusMap::JobStatusMap( int _myrank, int _size )
-  : size(_size),
-    myrank(_myrank),
-    wait_jobs( myrank, size, TRUE ),
-    exec_jobs( myrank, size, FALSE ),
-    exit_jobs( myrank, size, FALSE ),
-    start_time( myrank, size, 0 ),
-    end_time( myrank, size, 0 )
+JobStatusMap::JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm )
+  : myrank(_myrank),
+    size(_size),
+    noderank(_noderank),
+    nodesize(_nodesize),
+    nodecomm(_nodecomm),
+    wait_jobs( myrank, size, noderank, nodesize, nodecomm, TRUE ),
+    exec_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
+    exit_jobs( myrank, size, noderank, nodesize, nodecomm, FALSE ),
+    start_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
+    end_time( myrank, size, noderank, nodesize, nodecomm, 0 ),
+    o(string(LOG_DIR)+string("/mpi.job_map.log"))
 {}
 
 

--- a/job_status_map.cpp
+++ b/job_status_map.cpp
@@ -16,13 +16,13 @@ JobStatusMap::JobStatusMap( int _myrank, int _size )
     exec_jobs( myrank, size, FALSE ),
     exit_jobs( myrank, size, FALSE ),
     start_time( myrank, size, 0 ),
-    end_time( myrank, size, 0 ),
-    o(string(LOG_DIR)+string("/mpi.job_map.log"))
+    end_time( myrank, size, 0 )
 {}
 
 
 void JobStatusMap::output_map(Command* cmd, ArgumentsList* arglist)
 {
+  std::ofstream o(string(LOG_DIR)+string("/mpi.job_map.log"));
   o << "wait exec exit job | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {
     auto now = static_cast<TIME_T>(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
@@ -39,7 +39,7 @@ void JobStatusMap::output_map(Command* cmd, ArgumentsList* arglist)
       << setw(40) << left << cmd->get_str() + " " + (*arglist)[i] << " "
       << setw(20) << right << t << " sec." << endl;
   }
-  o.flush();
+  o.close();
 }
 
 void

--- a/job_status_map.hpp
+++ b/job_status_map.hpp
@@ -8,8 +8,11 @@
 
 class JobStatusMap
 {
-    int size;
-    int myrank;
+    const int myrank;
+    const int size;
+    const int noderank;
+    const int nodesize;
+    const MPI_Comm nodecomm;
     MPISharedMap<int> wait_jobs;
     MPISharedMap<int> exec_jobs;
     MPISharedMap<int> exit_jobs;
@@ -17,7 +20,7 @@ class JobStatusMap
     MPISharedMap<TIME_T> end_time;
 
     public:
-    JobStatusMap( int _myrank, int _size );
+    JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
     virtual ~JobStatusMap(){
     }
 

--- a/job_status_map.hpp
+++ b/job_status_map.hpp
@@ -1,5 +1,5 @@
 #include "mpi.h"
-#include "mpi_shared_map.hpp"
+#include "mpi_shared_array.hpp"
 #include "command.hpp"
 #include "argument_list.hpp"
 
@@ -13,11 +13,11 @@ class JobStatusMap
     const int noderank;
     const int nodesize;
     const MPI_Comm nodecomm;
-    MPISharedMap<int> wait_jobs;
-    MPISharedMap<int> exec_jobs;
-    MPISharedMap<int> exit_jobs;
-    MPISharedMap<TIME_T> start_time;
-    MPISharedMap<TIME_T> end_time;
+    MPISharedArray<int> wait_jobs;
+    MPISharedArray<int> exec_jobs;
+    MPISharedArray<int> exit_jobs;
+    MPISharedArray<TIME_T> start_time;
+    MPISharedArray<TIME_T> end_time;
 
     public:
     JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);

--- a/job_status_map.hpp
+++ b/job_status_map.hpp
@@ -15,12 +15,10 @@ class JobStatusMap
     MPISharedMap<int> exit_jobs;
     MPISharedMap<TIME_T> start_time;
     MPISharedMap<TIME_T> end_time;
-    std::ofstream o;
 
     public:
     JobStatusMap( int _myrank, int _size );
     virtual ~JobStatusMap(){
-        o.close();
     }
 
     void mpi_bcast_from( int root_rank ) {

--- a/job_status_map.hpp
+++ b/job_status_map.hpp
@@ -8,8 +8,11 @@
 
 class JobStatusMap
 {
-    int size;
-    int myrank;
+    const int myrank;
+    const int size;
+    const int noderank;
+    const int nodesize;
+    const MPI_Comm nodecomm;
     MPISharedMap<int> wait_jobs;
     MPISharedMap<int> exec_jobs;
     MPISharedMap<int> exit_jobs;
@@ -18,7 +21,7 @@ class JobStatusMap
     std::ofstream o;
 
     public:
-    JobStatusMap( int _myrank, int _size );
+    JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
     virtual ~JobStatusMap(){
         o.close();
     }

--- a/job_status_map.hpp
+++ b/job_status_map.hpp
@@ -18,12 +18,10 @@ class JobStatusMap
     MPISharedMap<int> exit_jobs;
     MPISharedMap<TIME_T> start_time;
     MPISharedMap<TIME_T> end_time;
-    std::ofstream o;
 
     public:
     JobStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
     virtual ~JobStatusMap(){
-        o.close();
     }
 
     void mpi_bcast_from( int root_rank ) {

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ CXX=mpic++
 LDFLAGS=-pthread
 CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic
 
-balancer: mpi_shared_map.o command.o argument_list.o job_status_map.o rank_status_map.o utilities.o balancer.o worker_thread.o worker_thread_manager.o
+balancer: mpi_shared_array.o command.o argument_list.o job_status_map.o rank_status_map.o utilities.o balancer.o worker_thread.o worker_thread_manager.o
 
 clean:
 	rm -f balancer *.o *~

--- a/mpi_shared_array.cpp
+++ b/mpi_shared_array.cpp
@@ -7,7 +7,7 @@ MPISharedArray<long long int>::mpi_bcast_from( int root_rank )
 {
     MPI_Win_fence(0,wintable);
 
-    auto ret = MPI_Bcast( map, size, MPI_LONG_LONG_INT, root_rank, MPI_COMM_WORLD );
+    auto ret = MPI_Bcast( map, _size, MPI_LONG_LONG_INT, root_rank, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
 
     MPI_Win_fence(0,wintable);
@@ -22,10 +22,10 @@ MPISharedArray<long long int>::mpi_send_to_recv_from( int dest, int source )
 
   assert(dest != source);
   if ( myrank == source ){
-    auto ret = MPI_Send( map, size, MPI_LONG_LONG_INT, dest, 0, MPI_COMM_WORLD );
+    auto ret = MPI_Send( map, _size, MPI_LONG_LONG_INT, dest, 0, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
   }else if ( myrank == dest ){
-    auto ret = MPI_Recv( map, size, MPI_LONG_LONG_INT, source, 0, MPI_COMM_WORLD, &stat );
+    auto ret = MPI_Recv( map, _size, MPI_LONG_LONG_INT, source, 0, MPI_COMM_WORLD, &stat );
     assert(ret == MPI_SUCCESS);
   }
 }
@@ -37,7 +37,7 @@ MPISharedArray<int>::mpi_bcast_from( int root_rank )
 {
     MPI_Win_fence(0,wintable);
 
-    auto ret = MPI_Bcast( map, size, MPI_INT, root_rank, MPI_COMM_WORLD );
+    auto ret = MPI_Bcast( map, _size, MPI_INT, root_rank, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
 
     MPI_Win_fence(0,wintable);
@@ -51,10 +51,10 @@ MPISharedArray<int>::mpi_send_to_recv_from( int dest, int source )
 
   assert(dest != source);
   if ( myrank == source ){
-    auto ret = MPI_Send( map, size, MPI_INT, dest, 0, MPI_COMM_WORLD );
+    auto ret = MPI_Send( map, _size, MPI_INT, dest, 0, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
   }else if ( myrank == dest ){
-    auto ret = MPI_Recv( map, size, MPI_INT, source, 0, MPI_COMM_WORLD, &stat );
+    auto ret = MPI_Recv( map, _size, MPI_INT, source, 0, MPI_COMM_WORLD, &stat );
     assert(ret == MPI_SUCCESS);
   }
 }
@@ -66,7 +66,7 @@ MPISharedArray<char>::mpi_bcast_from( int root_rank )
 {
     MPI_Win_fence(0,wintable);
 
-    auto ret = MPI_Bcast( map, size, MPI_CHAR, root_rank, MPI_COMM_WORLD );
+    auto ret = MPI_Bcast( map, _size, MPI_CHAR, root_rank, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
 
     MPI_Win_fence(0,wintable);
@@ -80,10 +80,10 @@ MPISharedArray<char>::mpi_send_to_recv_from( int dest, int source )
 
   assert(dest != source);
   if ( myrank == source ){
-    auto ret = MPI_Send( map, size, MPI_CHAR, dest, 0, MPI_COMM_WORLD );
+    auto ret = MPI_Send( map, _size, MPI_CHAR, dest, 0, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
   }else if ( myrank == dest ){
-    auto ret = MPI_Recv( map, size, MPI_CHAR, source, 0, MPI_COMM_WORLD, &stat );
+    auto ret = MPI_Recv( map, _size, MPI_CHAR, source, 0, MPI_COMM_WORLD, &stat );
     assert(ret == MPI_SUCCESS);
   }
 }

--- a/mpi_shared_array.cpp
+++ b/mpi_shared_array.cpp
@@ -58,3 +58,32 @@ MPISharedArray<int>::mpi_send_to_recv_from( int dest, int source )
     assert(ret == MPI_SUCCESS);
   }
 }
+
+//specialized for char
+template<>
+void
+MPISharedArray<char>::mpi_bcast_from( int root_rank )
+{
+    MPI_Win_fence(0,wintable);
+
+    auto ret = MPI_Bcast( map, size, MPI_CHAR, root_rank, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
+
+    MPI_Win_fence(0,wintable);
+}
+
+template<>
+void
+MPISharedArray<char>::mpi_send_to_recv_from( int dest, int source )
+{
+  if (dest == source) return;
+
+  assert(dest != source);
+  if ( myrank == source ){
+    auto ret = MPI_Send( map, size, MPI_CHAR, dest, 0, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
+  }else if ( myrank == dest ){
+    auto ret = MPI_Recv( map, size, MPI_CHAR, source, 0, MPI_COMM_WORLD, &stat );
+    assert(ret == MPI_SUCCESS);
+  }
+}

--- a/mpi_shared_array.cpp
+++ b/mpi_shared_array.cpp
@@ -1,9 +1,9 @@
-#include "mpi_shared_map.hpp"
+#include "mpi_shared_array.hpp"
 
 //specialized for long long int
 template<>
 void
-MPISharedMap<long long int>::mpi_bcast_from( int root_rank )
+MPISharedArray<long long int>::mpi_bcast_from( int root_rank )
 {
     MPI_Win_fence(0,wintable);
 
@@ -16,7 +16,7 @@ MPISharedMap<long long int>::mpi_bcast_from( int root_rank )
 
 template<>
 void
-MPISharedMap<long long int>::mpi_send_to_recv_from( int dest, int source )
+MPISharedArray<long long int>::mpi_send_to_recv_from( int dest, int source )
 {
   if (dest == source) return;
 
@@ -33,7 +33,7 @@ MPISharedMap<long long int>::mpi_send_to_recv_from( int dest, int source )
 //specialized for int
 template<>
 void
-MPISharedMap<int>::mpi_bcast_from( int root_rank )
+MPISharedArray<int>::mpi_bcast_from( int root_rank )
 {
     MPI_Win_fence(0,wintable);
 
@@ -45,7 +45,7 @@ MPISharedMap<int>::mpi_bcast_from( int root_rank )
 
 template<>
 void
-MPISharedMap<int>::mpi_send_to_recv_from( int dest, int source )
+MPISharedArray<int>::mpi_send_to_recv_from( int dest, int source )
 {
   if (dest == source) return;
 

--- a/mpi_shared_array.hpp
+++ b/mpi_shared_array.hpp
@@ -1,5 +1,5 @@
-#ifndef __BALANCER__MPI_SHARED_MAP_HPP__
-#define __BALANCER__MPI_SHARED_MAP_HPP__
+#ifndef __BALANCER__MPI_SHARED_ARRAY_HPP__
+#define __BALANCER__MPI_SHARED_ARRAY_HPP__
 
 #include "mpi.h"
 #include <cassert>
@@ -9,7 +9,7 @@
 #include "define.hpp"
 
 template <typename TYPE>
-class MPISharedMap
+class MPISharedArray
 {
 protected:
   const int myrank;
@@ -29,8 +29,8 @@ protected:
   MPI_Win wintable;
   
 public:
-  MPISharedMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
-  virtual ~MPISharedMap(){
+  MPISharedArray( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
+  virtual ~MPISharedArray(){
     MPI_Win_fence(0, wintable);
     MPI_Win_free(&wintable); 
     map = nullptr;
@@ -48,7 +48,7 @@ public:
 
 
 template<typename TYPE>
-MPISharedMap<TYPE>::MPISharedMap( int _myrank, int _size, int _noderank, 
+MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
                                   int _nodesize, MPI_Comm _nodecomm, TYPE initial )
     : myrank(_myrank), size(_size), 
       noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
@@ -116,20 +116,20 @@ MPISharedMap<TYPE>::MPISharedMap( int _myrank, int _size, int _noderank,
 
 template<typename TYPE> 
 TYPE&
-MPISharedMap<TYPE>::operator[]( int i ) { 
+MPISharedArray<TYPE>::operator[]( int i ) { 
     return map[i]; 
 } 
 
 // template<typename TYPE>
 // void
-// MPISharedMap<TYPE>::mpi_bcast_from( int root_rank )
+// MPISharedArray<TYPE>::mpi_bcast_from( int root_rank )
 // {
 //   MPI_Bcast( map, size, TYPE, root_rank, MPI_COMM_WORLD );
 // }
 
 // template<typename TYPE>
 // void
-// MPISharedMap<TYPE>::mpi_send_to_recv_from( int dest, int source )
+// MPISharedArray<TYPE>::mpi_send_to_recv_from( int dest, int source )
 // {
 //   assert(dest != source);
 //   if ( myrank == source )
@@ -140,7 +140,7 @@ MPISharedMap<TYPE>::operator[]( int i ) {
 
 template<typename TYPE>
 bool
-MPISharedMap<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
+MPISharedArray<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
 {
   for( int i = 0; i < size; i++ ) if( cmap[i] != map[i] ) return false;
   return true;
@@ -148,7 +148,7 @@ MPISharedMap<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
 
 template<typename TYPE>
 void
-MPISharedMap<TYPE>::copy_map(std::vector<TYPE>& cmap )
+MPISharedArray<TYPE>::copy_map(std::vector<TYPE>& cmap )
 {
   for( int i = 0; i < size; i++ ) cmap[i] = map[i];
 }

--- a/mpi_shared_array.hpp
+++ b/mpi_shared_array.hpp
@@ -27,16 +27,29 @@ protected:
   int windisp;
   int *winptr;
   MPI_Win wintable;
+
+  void allocate_shared_memory();
   
 public:
   MPISharedArray( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
+
+  MPISharedArray( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE* initial[] );
+
   virtual ~MPISharedArray(){
     MPI_Win_fence(0, wintable);
     MPI_Win_free(&wintable); 
     map = nullptr;
   }
 
-  TYPE& operator[] ( int i );
+  TYPE& operator[] ( int i ) 
+  { 
+      //after calling this function, mpi_bcast_from must be called to apply the change to the all process 
+      return map[i]; 
+  };
+
+  int size() const { return size; };
+
+  TYPE* data() const { return map; };
   
   void mpi_bcast_from( int root_rank );
   void mpi_send_to_recv_from( int dest, int source );
@@ -46,112 +59,7 @@ public:
 
 };
 
-
-template<typename TYPE>
-MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
-                                  int _nodesize, MPI_Comm _nodecomm, TYPE initial )
-    : myrank(_myrank), size(_size), 
-      noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
-{
-    TYPE *localmap;
-
-    // only rank 0 on a node actually allocates memory
-    if(noderank != 0){
-        localsize = 0;
-    }else{
-        localsize=size;
-    }
-
-    /*
-    std::cout << "myank:" << myrank << ", noderank:" << noderank << " of " << nodesize
-              << " size = " << size << std:: endl;
-    */
-
-    MPI_Win_allocate_shared(localsize*sizeof(TYPE), sizeof(TYPE),
-                  MPI_INFO_NULL, nodecomm, &localmap, &wintable);
-
-    int *model;
-    int flag;
-    MPI_Win_get_attr(wintable, MPI_WIN_MODEL, &model, &flag);
-
-    if (1 != flag)
-    {
-        printf("Attribute MPI_WIN_MODEL not defined\n");
-    }
-    else
-    {
-        if (MPI_WIN_UNIFIED == *model)
-        {
-            if (myrank == 0) printf("Memory model is MPI_WIN_UNIFIED\n");
-        }
-        else
-        {
-            if (myrank == 0) printf("Memory model is *not* MPI_WIN_UNIFIED\n");
-            std::exit(1);
-        }
-    }
-
-
-    map = localmap;
-
-    if (noderank !=0){
-        MPI_Win_shared_query(wintable, 0, &winsize, &windisp, &map);
-        assert(windisp == sizeof(TYPE));
-    }
-
-    // All table pointers should now point to copy on noderank 0
-
-    MPI_Win_fence(0, wintable);
-
-    // Initialize table on rank 0 with appropriate synchronization
-
-    if (noderank == 0){
-        for (auto i = TYPE{0}; i < size; ++i){
-            map[i] = initial;
-        }
-    }
-    MPI_Win_fence(0, wintable);
-
-}
-
-template<typename TYPE> 
-TYPE&
-MPISharedArray<TYPE>::operator[]( int i ) { 
-    return map[i]; 
-} 
-
-// template<typename TYPE>
-// void
-// MPISharedArray<TYPE>::mpi_bcast_from( int root_rank )
-// {
-//   MPI_Bcast( map, size, TYPE, root_rank, MPI_COMM_WORLD );
-// }
-
-// template<typename TYPE>
-// void
-// MPISharedArray<TYPE>::mpi_send_to_recv_from( int dest, int source )
-// {
-//   assert(dest != source);
-//   if ( myrank == source )
-//     MPI_Send( map, size, TYPE, dest, 0, MPI_COMM_WORLD );
-//   else if ( myrank == dest )
-//     MPI_Recv( map, size, TYPE, source, 0, MPI_COMM_WORLD, &stat );
-// }
-
-template<typename TYPE>
-bool
-MPISharedArray<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
-{
-  for( int i = 0; i < size; i++ ) if( cmap[i] != map[i] ) return false;
-  return true;
-}
-
-template<typename TYPE>
-void
-MPISharedArray<TYPE>::copy_map(std::vector<TYPE>& cmap )
-{
-  for( int i = 0; i < size; i++ ) cmap[i] = map[i];
-}
-
+// implementations (not specialized) of menber functions
+#include "mpi_shared_array_impl.hpp"
 
 #endif

--- a/mpi_shared_array.hpp
+++ b/mpi_shared_array.hpp
@@ -13,7 +13,7 @@ class MPISharedArray
 {
 protected:
   const int myrank;
-  const int size;
+  const int _size;
   TYPE *map;
   MPI_Status stat;
 
@@ -31,9 +31,9 @@ protected:
   void allocate_shared_memory();
   
 public:
-  MPISharedArray( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
+  MPISharedArray( int _myrank, int __size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
 
-  MPISharedArray( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE* initial[] );
+  MPISharedArray( int _myrank, int __size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial[] );
 
   virtual ~MPISharedArray(){
     MPI_Win_fence(0, wintable);
@@ -47,7 +47,7 @@ public:
       return map[i]; 
   };
 
-  int size() const { return size; };
+  int size() const { return _size; };
 
   TYPE* data() const { return map; };
   

--- a/mpi_shared_array_impl.hpp
+++ b/mpi_shared_array_impl.hpp
@@ -1,0 +1,134 @@
+template<typename TYPE>
+MPISharedArray<TYPE>::allocate_shared_memory()
+{
+    TYPE *localmap;
+
+    // only rank 0 on a node actually allocates memory
+    if(noderank != 0){
+        localsize = 0;
+    }else{
+        localsize=size;
+    }
+
+    /*
+    std::cout << "myank:" << myrank << ", noderank:" << noderank << " of " << nodesize
+              << " size = " << size << std:: endl;
+    */
+
+    MPI_Win_allocate_shared(localsize*sizeof(TYPE), sizeof(TYPE),
+                  MPI_INFO_NULL, nodecomm, &localmap, &wintable);
+
+    int *model;
+    int flag;
+    MPI_Win_get_attr(wintable, MPI_WIN_MODEL, &model, &flag);
+
+    if (1 != flag)
+    {
+        printf("Attribute MPI_WIN_MODEL not defined\n");
+    }
+    else
+    {
+        if (MPI_WIN_UNIFIED == *model)
+        {
+            if (myrank == 0) printf("Memory model is MPI_WIN_UNIFIED\n");
+        }
+        else
+        {
+            if (myrank == 0) printf("Memory model is *not* MPI_WIN_UNIFIED\n");
+            std::exit(1);
+        }
+    }
+
+
+    map = localmap;
+
+    if (noderank !=0){
+        MPI_Win_shared_query(wintable, 0, &winsize, &windisp, &map);
+        assert(windisp == sizeof(TYPE));
+    }
+
+    return;
+}
+
+template<typename TYPE>
+MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
+                                  int _nodesize, MPI_Comm _nodecomm, TYPE initial )
+    : myrank(_myrank), size(_size), 
+      noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
+{
+    allocate_shared_memory();
+
+    // All table pointers should now point to copy on noderank 0
+
+    MPI_Win_fence(0, wintable);
+
+    // Initialize table on rank 0 with appropriate synchronization
+
+    if (noderank == 0){
+        for (auto i = decltype(size){0}; i < size; ++i){
+            map[i] = initial;
+        }
+    }
+
+    MPI_Win_fence(0, wintable);
+
+}
+
+template<typename TYPE>
+MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
+                                  int _nodesize, MPI_Comm _nodecomm, TYPE* initial[] )
+    : myrank(_myrank), size(_size), 
+      noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
+{
+    allocate_shared_memory();
+
+    // All table pointers should now point to copy on noderank 0
+
+    MPI_Win_fence(0, wintable);
+
+    // Initialize table on rank 0 with appropriate synchronization
+
+    if (noderank == 0){
+        for (auto i = decltype(size){0}; i < size; ++i){
+            map[i] = initial[i];
+        }
+    }
+
+    MPI_Win_fence(0, wintable);
+
+}
+
+// template<typename TYPE>
+// void
+// MPISharedArray<TYPE>::mpi_bcast_from( int root_rank )
+// {
+//   MPI_Bcast( map, size, TYPE, root_rank, MPI_COMM_WORLD );
+// }
+
+// template<typename TYPE>
+// void
+// MPISharedArray<TYPE>::mpi_send_to_recv_from( int dest, int source )
+// {
+//   assert(dest != source);
+//   if ( myrank == source )
+//     MPI_Send( map, size, TYPE, dest, 0, MPI_COMM_WORLD );
+//   else if ( myrank == dest )
+//     MPI_Recv( map, size, TYPE, source, 0, MPI_COMM_WORLD, &stat );
+// }
+
+template<typename TYPE>
+bool
+MPISharedArray<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
+{
+  for( int i = 0; i < size; i++ ) if( cmap[i] != map[i] ) return false;
+  return true;
+}
+
+template<typename TYPE>
+void
+MPISharedArray<TYPE>::copy_map(std::vector<TYPE>& cmap )
+{
+  for( int i = 0; i < size; i++ ) cmap[i] = map[i];
+}
+
+

--- a/mpi_shared_array_impl.hpp
+++ b/mpi_shared_array_impl.hpp
@@ -31,7 +31,8 @@ MPISharedArray<TYPE>::allocate_shared_memory()
     {
         if (MPI_WIN_UNIFIED == *model)
         {
-            if (myrank == 0) printf("Memory model is MPI_WIN_UNIFIED\n");
+            // do nothing
+            //if (myrank == 0) printf("Memory model is MPI_WIN_UNIFIED\n");
         }
         else
         {

--- a/mpi_shared_array_impl.hpp
+++ b/mpi_shared_array_impl.hpp
@@ -1,4 +1,5 @@
 template<typename TYPE>
+void
 MPISharedArray<TYPE>::allocate_shared_memory()
 {
     TYPE *localmap;
@@ -7,12 +8,12 @@ MPISharedArray<TYPE>::allocate_shared_memory()
     if(noderank != 0){
         localsize = 0;
     }else{
-        localsize=size;
+        localsize=_size;
     }
 
     /*
     std::cout << "myank:" << myrank << ", noderank:" << noderank << " of " << nodesize
-              << " size = " << size << std:: endl;
+              << " size = " << _size << std:: endl;
     */
 
     MPI_Win_allocate_shared(localsize*sizeof(TYPE), sizeof(TYPE),
@@ -51,9 +52,9 @@ MPISharedArray<TYPE>::allocate_shared_memory()
 }
 
 template<typename TYPE>
-MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
+MPISharedArray<TYPE>::MPISharedArray( int _myrank, int __size, int _noderank, 
                                   int _nodesize, MPI_Comm _nodecomm, TYPE initial )
-    : myrank(_myrank), size(_size), 
+    : myrank(_myrank), _size(__size), 
       noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
 {
     allocate_shared_memory();
@@ -65,7 +66,7 @@ MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank,
     // Initialize table on rank 0 with appropriate synchronization
 
     if (noderank == 0){
-        for (auto i = decltype(size){0}; i < size; ++i){
+        for (auto i = decltype(_size){0}; i < _size; ++i){
             map[i] = initial;
         }
     }
@@ -75,9 +76,9 @@ MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank,
 }
 
 template<typename TYPE>
-MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank, 
-                                  int _nodesize, MPI_Comm _nodecomm, TYPE* initial[] )
-    : myrank(_myrank), size(_size), 
+MPISharedArray<TYPE>::MPISharedArray( int _myrank, int __size, int _noderank, 
+                                  int _nodesize, MPI_Comm _nodecomm, TYPE initial[] )
+    : myrank(_myrank), _size(__size), 
       noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
 {
     allocate_shared_memory();
@@ -89,7 +90,7 @@ MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank,
     // Initialize table on rank 0 with appropriate synchronization
 
     if (noderank == 0){
-        for (auto i = decltype(size){0}; i < size; ++i){
+        for (auto i = decltype(_size){0}; i < _size; ++i){
             map[i] = initial[i];
         }
     }
@@ -102,7 +103,7 @@ MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank,
 // void
 // MPISharedArray<TYPE>::mpi_bcast_from( int root_rank )
 // {
-//   MPI_Bcast( map, size, TYPE, root_rank, MPI_COMM_WORLD );
+//   MPI_Bcast( map, _size, TYPE, root_rank, MPI_COMM_WORLD );
 // }
 
 // template<typename TYPE>
@@ -111,16 +112,16 @@ MPISharedArray<TYPE>::MPISharedArray( int _myrank, int _size, int _noderank,
 // {
 //   assert(dest != source);
 //   if ( myrank == source )
-//     MPI_Send( map, size, TYPE, dest, 0, MPI_COMM_WORLD );
+//     MPI_Send( map, _size, TYPE, dest, 0, MPI_COMM_WORLD );
 //   else if ( myrank == dest )
-//     MPI_Recv( map, size, TYPE, source, 0, MPI_COMM_WORLD, &stat );
+//     MPI_Recv( map, _size, TYPE, source, 0, MPI_COMM_WORLD, &stat );
 // }
 
 template<typename TYPE>
 bool
 MPISharedArray<TYPE>::is_equiv_map(std::vector<TYPE>&& cmap )
 {
-  for( int i = 0; i < size; i++ ) if( cmap[i] != map[i] ) return false;
+  for( int i = 0; i < _size; i++ ) if( cmap[i] != map[i] ) return false;
   return true;
 }
 
@@ -128,7 +129,7 @@ template<typename TYPE>
 void
 MPISharedArray<TYPE>::copy_map(std::vector<TYPE>& cmap )
 {
-  for( int i = 0; i < size; i++ ) cmap[i] = map[i];
+  for( int i = 0; i < _size; i++ ) cmap[i] = map[i];
 }
 
 

--- a/mpi_shared_map.cpp
+++ b/mpi_shared_map.cpp
@@ -1,43 +1,56 @@
 #include "mpi_shared_map.hpp"
 
 //specialized for long long int
-
 template<>
 void
 MPISharedMap<long long int>::mpi_bcast_from( int root_rank )
 {
-  auto ret = MPI_Bcast( map.data(), size, MPI_LONG_LONG_INT, root_rank, MPI_COMM_WORLD );
-  assert(ret == MPI_SUCCESS);
+    MPI_Win_fence(0,wintable);
+
+    auto ret = MPI_Bcast( map, size, MPI_LONG_LONG_INT, root_rank, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
 }
+
 
 template<>
 void
 MPISharedMap<long long int>::mpi_send_to_recv_from( int dest, int source )
 {
+  if (dest == source) return;
+
   assert(dest != source);
-  if ( myrank == source )
-    MPI_Send( map.data(), size, MPI_LONG_LONG_INT, dest, 0, MPI_COMM_WORLD );
-  else if ( myrank == dest )
-    MPI_Recv( map.data(), size, MPI_LONG_LONG_INT, source, 0, MPI_COMM_WORLD, &stat );
+  if ( myrank == source ){
+    auto ret = MPI_Send( map, size, MPI_LONG_LONG_INT, dest, 0, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
+  }else if ( myrank == dest ){
+    auto ret = MPI_Recv( map, size, MPI_LONG_LONG_INT, source, 0, MPI_COMM_WORLD, &stat );
+    assert(ret == MPI_SUCCESS);
+  }
 }
 
 //specialized for int
-
 template<>
 void
 MPISharedMap<int>::mpi_bcast_from( int root_rank )
 {
-  auto ret = MPI_Bcast( map.data(), size, MPI_INT, root_rank, MPI_COMM_WORLD );
-  assert(ret == MPI_SUCCESS);
+    MPI_Win_fence(0,wintable);
+
+    auto ret = MPI_Bcast( map, size, MPI_INT, root_rank, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
 }
 
 template<>
 void
 MPISharedMap<int>::mpi_send_to_recv_from( int dest, int source )
 {
+  if (dest == source) return;
+
   assert(dest != source);
-  if ( myrank == source )
-    MPI_Send( map.data(), size, MPI_INT, dest, 0, MPI_COMM_WORLD );
-  else if ( myrank == dest )
-    MPI_Recv( map.data(), size, MPI_INT, source, 0, MPI_COMM_WORLD, &stat );
+  if ( myrank == source ){
+    auto ret = MPI_Send( map, size, MPI_INT, dest, 0, MPI_COMM_WORLD );
+    assert(ret == MPI_SUCCESS);
+  }else if ( myrank == dest ){
+    auto ret = MPI_Recv( map, size, MPI_INT, source, 0, MPI_COMM_WORLD, &stat );
+    assert(ret == MPI_SUCCESS);
+  }
 }

--- a/mpi_shared_map.cpp
+++ b/mpi_shared_map.cpp
@@ -9,6 +9,8 @@ MPISharedMap<long long int>::mpi_bcast_from( int root_rank )
 
     auto ret = MPI_Bcast( map, size, MPI_LONG_LONG_INT, root_rank, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
+
+    MPI_Win_fence(0,wintable);
 }
 
 
@@ -37,6 +39,8 @@ MPISharedMap<int>::mpi_bcast_from( int root_rank )
 
     auto ret = MPI_Bcast( map, size, MPI_INT, root_rank, MPI_COMM_WORLD );
     assert(ret == MPI_SUCCESS);
+
+    MPI_Win_fence(0,wintable);
 }
 
 template<>

--- a/mpi_shared_map.hpp
+++ b/mpi_shared_map.hpp
@@ -4,6 +4,7 @@
 #include "mpi.h"
 #include <cassert>
 #include <vector>
+#include <iostream>
 
 #include "define.hpp"
 
@@ -11,41 +12,110 @@ template <typename TYPE>
 class MPISharedMap
 {
 protected:
-  int myrank;
-  int size;
-  std::vector<TYPE> map;
+  const int myrank;
+  const int size;
+  TYPE *map;
   MPI_Status stat;
+
+  const int noderank;
+  const int nodesize;
+  const MPI_Comm nodecomm;
+
+  int localsize;
+
+  MPI_Aint winsize;
+  int windisp;
+  int *winptr;
+  MPI_Win wintable;
   
 public:
-  MPISharedMap( int _myrank, int _size, TYPE initial );
-  TYPE& operator[] ( int i ) &;
-  const TYPE& operator[] ( int i ) const&;
-  TYPE operator[] ( int i ) const&&;
+  MPISharedMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
+  virtual ~MPISharedMap(){
+    delete[] map;
+  }
+  TYPE& operator[] ( int i );
   
   void mpi_bcast_from( int root_rank );
   void mpi_send_to_recv_from( int dest, int source );
 
   bool is_equiv_map( std::vector<TYPE>&& cmap );
   void copy_map( std::vector<TYPE>& cmap );
+
 };
 
 
 template<typename TYPE>
-MPISharedMap<TYPE>::MPISharedMap( int _myrank, int _size, TYPE initial )
-  : myrank(_myrank), size(_size), map(size, initial)
-   {}
+MPISharedMap<TYPE>::MPISharedMap( int _myrank, int _size, int _noderank, 
+                                  int _nodesize, MPI_Comm _nodecomm, TYPE initial )
+    : myrank(_myrank), size(_size), 
+      noderank(_noderank), nodesize(_nodesize), nodecomm(_nodecomm)
+{
+    TYPE *localmap;
+
+    // only rank 0 on a node actually allocates memory
+    if(noderank != 0){
+        localsize = 0;
+    }else{
+        localsize=size;
+    }
+
+    /*
+    std::cout << "myank:" << myrank << ", noderank:" << noderank << " of " << nodesize
+              << " size = " << size << std:: endl;
+    */
+
+    MPI_Win_allocate_shared(localsize*sizeof(TYPE), sizeof(TYPE),
+                  MPI_INFO_NULL, nodecomm, &localmap, &wintable);
+
+    int *model;
+    int flag;
+    MPI_Win_get_attr(wintable, MPI_WIN_MODEL, &model, &flag);
+
+    if (1 != flag)
+    {
+        printf("Attribute MPI_WIN_MODEL not defined\n");
+    }
+    else
+    {
+        if (MPI_WIN_UNIFIED == *model)
+        {
+            if (myrank == 0) printf("Memory model is MPI_WIN_UNIFIED\n");
+        }
+        else
+        {
+            if (myrank == 0) printf("Memory model is *not* MPI_WIN_UNIFIED\n");
+            std::exit(1);
+        }
+    }
+
+
+    map = localmap;
+
+    if (noderank !=0){
+        MPI_Win_shared_query(wintable, 0, &winsize, &windisp, &map);
+        assert(windisp == sizeof(TYPE));
+    }
+
+    // All table pointers should now point to copy on noderank 0
+
+    MPI_Win_fence(0, wintable);
+
+    // Initialize table on rank 0 with appropriate synchronization
+
+    if (noderank == 0){
+        for (auto i = TYPE{0}; i < size; ++i){
+            map[i] = initial;
+        }
+    }
+    MPI_Win_fence(0, wintable);
+
+}
 
 template<typename TYPE> 
 TYPE&
-MPISharedMap<TYPE>::operator[]( int i ) & { return map[i]; } 
-
-template<typename TYPE> 
-const TYPE&
-MPISharedMap<TYPE>::operator[]( int i ) const& { return map[i]; } 
-
-template<typename TYPE> 
-TYPE
-MPISharedMap<TYPE>::operator[]( int i ) const&& { return std::move(map[i]); } 
+MPISharedMap<TYPE>::operator[]( int i ) { 
+    return map[i]; 
+} 
 
 // template<typename TYPE>
 // void

--- a/mpi_shared_map.hpp
+++ b/mpi_shared_map.hpp
@@ -31,8 +31,13 @@ protected:
 public:
   MPISharedMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
   virtual ~MPISharedMap(){
-    delete[] map;
+    MPI_Win_fence(0, wintable);
+    //if (noderank == 0) {
+        MPI_Win_free(&wintable); 
+    //}
+    map = nullptr;
   }
+
   TYPE& operator[] ( int i );
   
   void mpi_bcast_from( int root_rank );

--- a/mpi_shared_map.hpp
+++ b/mpi_shared_map.hpp
@@ -32,9 +32,7 @@ public:
   MPISharedMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm, TYPE initial );
   virtual ~MPISharedMap(){
     MPI_Win_fence(0, wintable);
-    //if (noderank == 0) {
-        MPI_Win_free(&wintable); 
-    //}
+    MPI_Win_free(&wintable); 
     map = nullptr;
   }
 

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -8,9 +8,9 @@
 using namespace std;
 using namespace std::chrono;
 
-RankStatusMap::RankStatusMap( int _myrank, int _size )
-  : ranks_active( _myrank, _size, TRUE ),
-    ranks_duration( _myrank, _size, 0 ),
+RankStatusMap::RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm)
+  : ranks_active( _myrank, _size, _noderank, _nodesize, _nodecomm, TRUE ),
+    ranks_duration( _myrank, _size, _noderank, _nodesize, _nodecomm, 0 ),
     size(_size)
 {  
   for (int i = 0; i < size; i++){

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -10,7 +10,7 @@ using namespace std::chrono;
 
 RankStatusMap::RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm)
   : ranks_active( _myrank, _size, _noderank, _nodesize, _nodecomm, TRUE ),
-    ranks_duration( _myrank, _size, _noderank, _nodesize, _nodecomm, 0 ),
+    ranks_duration( _myrank, _size, _noderank, _nodesize, _nodecomm, TIME_T{0} ),
     size(_size)
 {  
   for (int i = 0; i < size; i++){

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -8,9 +8,9 @@
 using namespace std;
 using namespace std::chrono;
 
-RankStatusMap::RankStatusMap( int _myrank, int _size )
-  : ranks_active( _myrank, _size, TRUE ),
-    ranks_duration( _myrank, _size, 0 ),
+RankStatusMap::RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm)
+  : ranks_active( _myrank, _size, _noderank, _nodesize, _nodecomm, TRUE ),
+    ranks_duration( _myrank, _size, _noderank, _nodesize, _nodecomm, 0 ),
     size(_size),
     o(string(LOG_DIR)+string("/mpi.rank_map.log"))
 {  

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -11,8 +11,7 @@ using namespace std::chrono;
 RankStatusMap::RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm)
   : ranks_active( _myrank, _size, _noderank, _nodesize, _nodecomm, TRUE ),
     ranks_duration( _myrank, _size, _noderank, _nodesize, _nodecomm, 0 ),
-    size(_size),
-    o(string(LOG_DIR)+string("/mpi.rank_map.log"))
+    size(_size)
 {  
   for (int i = 0; i < size; i++){
       auto now = static_cast<TIME_T>(duration_cast<seconds>(chrono::system_clock::now().time_since_epoch()).count());
@@ -33,6 +32,7 @@ RankStatusMap::setRankExit(int i)
 void RankStatusMap::output_map()
 {
   TIME_T duration;
+  std::ofstream o(string(LOG_DIR)+string("/mpi.rank_map.log"));
   
   o << "active rank | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {
@@ -46,5 +46,5 @@ void RankStatusMap::output_map()
       << setw(5) << i
       << setw(20) << right << duration << " sec." << endl;
   }
-  o.flush();
+  o.close();
 }

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -11,8 +11,7 @@ using namespace std::chrono;
 RankStatusMap::RankStatusMap( int _myrank, int _size )
   : ranks_active( _myrank, _size, TRUE ),
     ranks_duration( _myrank, _size, 0 ),
-    size(_size),
-    o(string(LOG_DIR)+string("/mpi.rank_map.log"))
+    size(_size)
 {  
   for (int i = 0; i < size; i++){
       auto now = static_cast<TIME_T>(duration_cast<seconds>(chrono::system_clock::now().time_since_epoch()).count());
@@ -33,6 +32,7 @@ RankStatusMap::setRankExit(int i)
 void RankStatusMap::output_map()
 {
   TIME_T duration;
+  std::ofstream o(string(LOG_DIR)+string("/mpi.rank_map.log"));
   
   o << "active rank | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {
@@ -46,5 +46,5 @@ void RankStatusMap::output_map()
       << setw(5) << i
       << setw(20) << right << duration << " sec." << endl;
   }
-  o.flush();
+  o.close();
 }

--- a/rank_status_map.cpp
+++ b/rank_status_map.cpp
@@ -32,7 +32,7 @@ RankStatusMap::setRankExit(int i)
 void RankStatusMap::output_map()
 {
   TIME_T duration;
-  std::ofstream o(string(LOG_DIR)+string("/mpi.rank_map.log"));
+  auto o = ofstream{string(LOG_DIR)+string("/mpi.rank_map.log")};
   
   o << "active rank | " << localtimestamp() << endl;
   for ( int i = 0; i < size; i++ ) {

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -11,13 +11,11 @@ class RankStatusMap
   MPISharedMap<TIME_T> ranks_duration;
 
   const int size;
-  std::ofstream o;
   
 public:
   RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
   virtual ~RankStatusMap()
   {
-    o.close();
   }
 
   void mpi_bcast_from( int root_rank ) {

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -13,7 +13,7 @@ class RankStatusMap
   int size;
   
 public:
-  RankStatusMap( int _myrank, int _size );
+  RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
   virtual ~RankStatusMap()
   {
   }

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -1,4 +1,4 @@
-#include "mpi_shared_map.hpp"
+#include "mpi_shared_array.hpp"
 #include "define.hpp"
 #include "utilities.hpp"
 
@@ -7,8 +7,8 @@
 
 class RankStatusMap
 {
-  MPISharedMap<int> ranks_active;
-  MPISharedMap<TIME_T> ranks_duration;
+  MPISharedArray<int> ranks_active;
+  MPISharedArray<TIME_T> ranks_duration;
 
   const int size;
   

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -10,11 +10,11 @@ class RankStatusMap
   MPISharedMap<int> ranks_active;
   MPISharedMap<TIME_T> ranks_duration;
 
-  int size;
+  const int size;
   std::ofstream o;
   
 public:
-  RankStatusMap( int _myrank, int _size );
+  RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);
   virtual ~RankStatusMap()
   {
     o.close();

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -10,7 +10,7 @@ class RankStatusMap
   MPISharedMap<int> ranks_active;
   MPISharedMap<TIME_T> ranks_duration;
 
-  int size;
+  const int size;
   
 public:
   RankStatusMap( int _myrank, int _size, int _noderank, int _nodesize, MPI_Comm _nodecomm);

--- a/rank_status_map.hpp
+++ b/rank_status_map.hpp
@@ -11,13 +11,11 @@ class RankStatusMap
   MPISharedMap<TIME_T> ranks_duration;
 
   int size;
-  std::ofstream o;
   
 public:
   RankStatusMap( int _myrank, int _size );
   virtual ~RankStatusMap()
   {
-    o.close();
   }
 
   void mpi_bcast_from( int root_rank ) {


### PR DESCRIPTION
各プロセスが個別にメモリを確保するのは無駄なので，各ノードの特定のランクのみがShared memroyを生成し，ほかのプロセスはそれを使用することでメモリ使用量の削減を試みます